### PR TITLE
Draft Pull request - some proposals for optimization

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -612,6 +612,7 @@
                                         <th data-name="hysteresisLight" data-type="number" style="width: 0px" class="translate">hysteresisLight</th>
                                         <th data-name="currentAction" style="width: 0px" data-style="width: 0px" data-type="text" class="translate">current Action</th>
                                         <th data-name="currentHeight" data-type="number" style="width: 0px" class="translate"></th>
+                                        <th data-name="oldHeight" data-type="number" style="width: 0px" class="translate"></th>
                                         <th data-name="triggerHeight" data-type="number" style="width: 0px" class="translate"></th>
                                         <!-- ****************************************************************** -->
                                         <th data-buttons="edit up down delete" style="width: 100px; background: #64b5f6"></th>

--- a/main.js
+++ b/main.js
@@ -2101,12 +2101,12 @@ function sunProtect() {
                                                                                         adapter.log.debug('Sunprotect ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDownSun + '%')
                                                                                         adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + result[i].heightDownSun + '%')
                                                                                         adapter.setForeignState(result[i].name, parseFloat(result[i].heightDownSun), false);
-                                                                                        shutterState(result[i].name);
                                                                                         result[i].currentHeight = result[i].heightDownSun;
                                                                                         adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                                                        shutterState(result[i].name);
                                                                                     }
-                                                                                    //Shutter closed. Set currentAction = sunProtect when sunProtect would start => If shutter is opened automatically it can be opened in height heightDownSun directly
-                                                                                    else if (parseFloat(state.val) == parseFloat(result[i].heightDown) && parseFloat(state.val) == parseFloat(result[i].currentHeight) && result[i].currentHeight != result[i].heightUp && result[i].currentAction != 'down') { //check currentAction !=down here. If shutter is already closed sunProtect must not be set
+                                                                                    //Shutter closed. Set currentAction = sunProtect when sunProtect starts => If shutter is opened automatically it can be opened in height heightDownSun directly
+                                                                                    else if (parseFloat(state.val) == parseFloat(result[i].heightDown) && parseFloat(state.val) == parseFloat(result[i].currentHeight) && result[i].currentHeight != result[i].heightUp && result[i].currentAction != 'down') { //check currentAction!=down here. If shutter is already closed sunProtect must not be set. Otherwise shutter will be opened again when sunProtect ends!
                                                                                         result[i].currentAction = 'sunProtect';
                                                                                         adapter.log.debug('Set sunprotect mode for ' + result[i].shutterName + '. Currently closed. Set to sunprotect if shutter will be opened automatically');
                                                                                     }

--- a/main.js
+++ b/main.js
@@ -175,11 +175,32 @@ function startAdapter(options) {
                     sunProtect();
                 }
             });
-            resShutterState.forEach(function (resShutterID) {
-                if (id === resShutterID && state.ts === state.lc) {
+            resShutterState.forEach(function(resShutterID) {
+                if (id === resShutterID  && state.ts === state.lc) {
                     resShutterChange = resShutterID;
-                    adapter.log.debug('shutter state changed: ' + resShutterID + ' Value: ' + state.val);
-                    //shutterState();
+                    const resultID = adapter.config.events;
+                    const result = resultID.filter(d => d.name == resShutterID);
+                    for ( const i in result) {
+                        adapter.getForeignState(result[i].name, (err, state) => {
+                            //if (state && result[i].currentHeight != state.val) {
+                               //adapter.log.debug('old Position value: ' + result[i].currentHeight);
+                            //}
+                            adapter.log.debug('Shutter state changed: ' + result[i].shutterName + ' old value = ' + result[i].oldHeight + ' new value = ' + state.val);
+                        });
+                        //shutterState(resShutterID);
+                        //setTimeout(function() {
+                        //shutterState(resShutterID);
+                        //},1000)
+                        //Shutter closed -> opened manually to 100% before it has been opened automatically -> enable possibility to activate sunprotect height if required
+                        if (result[i].oldHeight == result[i].heightDown && state.val == 100 && result[i].currentAction != 'up') {
+                            result[i].currentHeight = state.val;
+                            result[i].currentAction = ''; //reset mode. e.g. mode could be sunProtect if shutter was still closed
+                            adapter.log.debug(result[i].shutterName + ' opened manually to 100%. Old value = ' + result[i].oldHeight + '. New value = ' + state.val + '. Possibility to activate sunprotect enabled.');
+                        }
+                        setTimeout(function() {
+                            result[i].oldHeight = state.val;    //set old Height after 60 Sek - after 60 Sek end position should be reached
+                        },60000)
+                    }
                 }
             });
 
@@ -429,6 +450,17 @@ function checkActualStates() {
 
 const calc = schedule.scheduleJob('calcTimer', '30 2 * * *', function () {
     shutterDriveCalc();
+    //Reset currentAction in the night
+    const resultStates = adapter.config.events;
+    if (resultStates) {
+        for ( const i in resultStates) {
+            adapter.getForeignState(resultStates[i].name, (err, state) => {
+                if (state) {
+                    resultStates[i].currentAction = '';     //Case: Auto-down in the evening. Sun sill shining. currentAction=sunprotect would be set. But not if currentAction=down. So this is check in sunProtect(). Reset here to enable possibility to set sunProtect in the morning
+                }
+            });
+        }
+    }     
 });
 
 function shutterDriveCalc() {
@@ -1210,7 +1242,8 @@ function shutterUpLiving() {
                                             adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                             adapter.setForeignState(result[i].name, shutterHeight, false);
                                             result[i].currentHeight = shutterHeight;
-                                            adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                            adapter.log.debug('shutterUpLiving #1 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                            //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                             shutterState(result[i].name);
                                         }
                                     });
@@ -1224,7 +1257,8 @@ function shutterUpLiving() {
                                             adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                             adapter.setForeignState(result[i].name, shutterHeight, false);
                                             result[i].currentHeight = shutterHeight;
-                                            adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                            adapter.log.debug('shutterUpLiving #2 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                            //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                             shutterState(result[i].name);
                                         }
                                     });
@@ -1287,7 +1321,8 @@ function shutterUpLiving() {
                                                     adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                                     adapter.setForeignState(result[i].name, shutterHeight, false);
                                                     result[i].currentHeight = shutterHeight;
-                                                    adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                    adapter.log.debug('shutterUpLiving #3 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                                    //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                     shutterState(result[i].name);
                                                 }
                                             });
@@ -1301,7 +1336,8 @@ function shutterUpLiving() {
                                                     adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                                     adapter.setForeignState(result[i].name, shutterHeight, false);
                                                     result[i].currentHeight = shutterHeight;
-                                                    adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                    adapter.log.debug('shutterUpLiving #4 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                                    //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                     shutterState(result[i].name);
                                                 }
                                             });
@@ -1385,7 +1421,8 @@ function shutterDownLiving() {
                                             adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                             result[i].currentHeight = result[i].heightDown;
                                             result[i].currentAction = 'down';
-                                            adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                            adapter.log.debug('shutterDownLiving #1 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDownt + '%')
+                                            //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                             shutterState(result[i].name);
                                         }
                                     });
@@ -1400,7 +1437,8 @@ function shutterDownLiving() {
                                             adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                             result[i].currentHeight = result[i].heightDown;
                                             result[i].currentAction = 'down';
-                                            adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                            adapter.log.debug('shutterDownLiving #2 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDown + '%')
+                                            //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                             shutterState(result[i].name);
                                         }
                                     });
@@ -1457,7 +1495,8 @@ function shutterDownLiving() {
                                                     adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                                     result[i].currentHeight = result[i].heightDown;
                                                     result[i].currentAction = 'down';
-                                                    adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                    adapter.log.debug('shutterDownLiving #3 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDown + '%')
+                                                    //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                     shutterState(result[i].name);
                                                 }
                                             });
@@ -1472,7 +1511,8 @@ function shutterDownLiving() {
                                                     adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                                     result[i].currentHeight = result[i].heightDown;
                                                     result[i].currentAction = 'down';
-                                                    adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                    adapter.log.debug('shutterDownLiving #4 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDown + '%')
+                                                    //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                     shutterState(result[i].name);
                                                 }
                                             });
@@ -1566,7 +1606,8 @@ function shutterUpSleep() {
                                                 adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                                 adapter.setForeignState(result[i].name, shutterHeight, false);
                                                 result[i].currentHeight = shutterHeight;
-                                                adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                adapter.log.debug('shutterUpSleep #1 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                                //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                 shutterState(result[i].name);
                                             }
                                         });
@@ -1580,7 +1621,8 @@ function shutterUpSleep() {
                                                 adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                                 adapter.setForeignState(result[i].name, shutterHeight, false);
                                                 result[i].currentHeight = shutterHeight;
-                                                adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                adapter.log.debug('shutterUpSleep #2 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                                //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                 shutterState(result[i].name);
                                             }
                                         });
@@ -1645,7 +1687,8 @@ function shutterUpSleep() {
                                                         adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                                         adapter.setForeignState(result[i].name, shutterHeight, false);
                                                         result[i].currentHeight = shutterHeight;
-                                                        adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                        adapter.log.debug('shutterUpSleep #3 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                                        //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                         shutterState(result[i].name);
                                                     }
                                                 });
@@ -1659,7 +1702,8 @@ function shutterUpSleep() {
                                                         adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + shutterHeight + '%')
                                                         adapter.setForeignState(result[i].name, shutterHeight, false);
                                                         result[i].currentHeight = shutterHeight;
-                                                        adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                        adapter.log.debug('shutterUpSleep #4 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + shutterHeight + '%')
+                                                        //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                         shutterState(result[i].name);
                                                     }
                                                 });
@@ -1747,7 +1791,8 @@ function shutterDownSleep() {
                                                 adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                                 result[i].currentHeight = result[i].heightDown;
                                                 result[i].currentAction = 'down';
-                                                adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                adapter.log.debug('shutterDownSleep #1 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDown + '%')
+                                                //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                 shutterState(result[i].name);
                                             }
                                         });
@@ -1762,7 +1807,8 @@ function shutterDownSleep() {
                                                 adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                                 result[i].currentHeight = result[i].heightDown;
                                                 result[i].currentAction = 'down';
-                                                adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                adapter.log.debug('shutterDownSleep #2 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDown + '%')
+                                                //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                 shutterState(result[i].name);
                                             }
                                         });
@@ -1822,7 +1868,8 @@ function shutterDownSleep() {
                                                         adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                                         result[i].currentHeight = result[i].heightDown;
                                                         result[i].currentAction = 'down';
-                                                        adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                        adapter.log.debug('shutterDownSleep #3 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDown + '%')
+                                                        //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                         shutterState(result[i].name);
                                                     }
                                                 });
@@ -1837,7 +1884,8 @@ function shutterDownSleep() {
                                                         adapter.setForeignState(result[i].name, parseFloat(result[i].heightDown), false);
                                                         result[i].currentHeight = result[i].heightDown;
                                                         result[i].currentAction = 'down';
-                                                        adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                        adapter.log.debug('shutterDownSleep #4 ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDown + '%')
+                                                        //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                         shutterState(result[i].name);
                                                     }
                                                 });
@@ -1947,7 +1995,8 @@ function sunProtect() {
                                                                                         adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + result[i].heightDownSun + '%')
                                                                                         adapter.setForeignState(result[i].name, parseFloat(result[i].heightDownSun), false);
                                                                                         result[i].currentHeight = result[i].heightDownSun;
-                                                                                        adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                                                        adapter.log.debug('Sunprotect ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDownSun + '%')
+                                                                                        //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                                                         shutterState(result[i].name);
                                                                                     }
                                                                                 }
@@ -1972,6 +2021,7 @@ function sunProtect() {
                                                                                     result[i].currentAction = '';
                                                                                     adapter.log.debug('Sunprotect for ' + result[i].shutterName + ' is not active');
                                                                                     adapter.log.debug('Temperature inside: ' + insideTemp + ' < ' + hysteresisInside + ' OR ( Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' AND Light: ' + sunLight + ' < ' + hysteresisLight + ' )');
+                                                                                    adapter.log.debug('Sunprotect ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDownSun + '%')
                                                                                     adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + result[i].heightUp + '%')
                                                                                     adapter.setForeignState(result[i].name, parseFloat(result[i].heightUp), false);
                                                                                     result[i].currentHeight = result[i].heightUp;
@@ -2039,7 +2089,7 @@ function sunProtect() {
                                                                 }
                                                                 if (currentValue === mustValue || (currentValue != mustValue && result[i].autoDrive != 'onlyUp') || (result[i].triggerID == '')) {
                                                                     if ((resultDirectionRangeMinus) < azimuth && (resultDirectionRangePlus) > azimuth && insideTemp > result[i].tempInside) {
-                                                                        if (result[i].tempOutside < outsideTemp || result[i].valueLight < sunLight) {
+                                                                        if (result[i].tempOutside < outsideTemp && result[i].valueLight < sunLight && result[i].currentAction != 'sunProtect') {
 
                                                                             /**
                                                                              * @param {any} err
@@ -2047,15 +2097,27 @@ function sunProtect() {
                                                                              */
                                                                             adapter.getForeignState(result[i].name, (err, state) => {
                                                                                 if (state) {
+                                                                                    //adapter.log.debug(result[i].shutterName + ': Check basis for sunprotect. Height:' + state.val + ' > HeightDownSun: ' + result[i].heightDownSun + ' AND Height:' + state.val + ' == currentHeight:' + result[i].currentHeight + ' AND currentHeight:' + result[i].currentHeight + ' == heightUp:' + result[i].heightUp);
                                                                                     if (parseFloat(state.val) > parseFloat(result[i].heightDownSun) && parseFloat(state.val) == parseFloat(result[i].currentHeight) && result[i].currentHeight == result[i].heightUp) {
                                                                                         result[i].currentAction = 'sunProtect';
                                                                                         adapter.log.debug('Sunprotect for ' + result[i].shutterName + ' is active');
-                                                                                        adapter.log.debug('Temperature inside: ' + insideTemp + ' > ' + result[i].tempInside + ' AND ( Temperatur outside: ' + outsideTemp + ' > ' + result[i].tempOutside + ' OR Light: ' + sunLight + ' > ' + result[i].valueLight + ' )');
+                                                                                        adapter.log.debug('Temperature inside: ' + insideTemp + ' > ' + result[i].tempInside + ' AND ( Temperatur outside: ' + outsideTemp + ' > ' + result[i].tempOutside  + ' AND Light: ' + sunLight + ' > ' + result[i].valueLight + ' )');
+                                                                                        adapter.log.debug('Sunprotect ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightDownSun + '%')
                                                                                         adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + result[i].heightDownSun + '%')
                                                                                         adapter.setForeignState(result[i].name, parseFloat(result[i].heightDownSun), false);
-                                                                                        result[i].currentHeight = result[i].heightDownSun;
-                                                                                        adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
                                                                                         shutterState(result[i].name);
+                                                                                        result[i].currentHeight = result[i].heightDownSun;
+                                                                                        //adapter.log.debug('save current height: ' + result[i].currentHeight + '%' + ' from ' + result[i].shutterName);
+                                                                                    }
+                                                                                    //Shutter closed. Set currentAction = sunProtect when sunProtect would start => If shutter is opened automatically it can be opened in height heightDownSun directly
+                                                                                    else if (parseFloat(state.val) == parseFloat(result[i].heightDown) && parseFloat(state.val) == parseFloat(result[i].currentHeight) && result[i].currentHeight != result[i].heightUp && result[i].currentAction != 'down') {
+                                                                                        result[i].currentAction = 'sunProtect';
+                                                                                        adapter.log.debug('Set sunprotect mode for ' + result[i].shutterName + '. Currently closed. Set to sunprotect if shutter will be opened automatically');
+                                                                                    }
+                                                                                    //Shutter is in position = sunProtect. Maybe restart of adapter. sunProtect not set -> set sunProtect
+                                                                                    else if (parseFloat(state.val) == parseFloat(result[i].heightDownSun) && parseFloat(state.val) == parseFloat(result[i].currentHeight) && result[i].currentHeight != result[i].heightUp && result[i].currentAction == '') {
+                                                                                        adapter.log.debug(result[i].shutterName + ': Shutter is in position sunProtect. Reset mode sunProtect to cancel sunProtect automatically. Height:' + state.val + ' HeightDownSun:' + result[i].heightDownSun);
+                                                                                        result[i].currentAction = 'sunProtect';
                                                                                     }
                                                                                 }
                                                                             });
@@ -2078,7 +2140,8 @@ function sunProtect() {
                                                                                 if (result[i].currentAction == 'sunProtect' && (parseFloat(state.val) == parseFloat(result[i].heightDownSun) || parseFloat(state.val) == parseFloat(result[i].currentHeight))) {
                                                                                     result[i].currentAction = '';
                                                                                     adapter.log.debug('Sunprotect for ' + result[i].shutterName + ' is not active');
-                                                                                    adapter.log.debug('Temperature inside: ' + insideTemp + ' < ' + hysteresisInside + ' OR ( Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' AND Light: ' + sunLight + ' < ' + hysteresisLight + ' )');
+                                                                                    adapter.log.debug('Range: ' + resultDirectionRangePlus + ' < ' + azimuth + ' OR Temperature inside: ' + insideTemp + ' < ' + hysteresisInside + ' OR ( Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside  + ' OR Light: ' + sunLight + ' < ' + hysteresisLight + ')');
+                                                                                    adapter.log.debug('Sunprotect ' + result[i].shutterName + ' old height: ' + result[i].oldHeight + '% new height: ' + result[i].heightUp + '%')
                                                                                     adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + result[i].heightUp + '%')
                                                                                     adapter.setForeignState(result[i].name, parseFloat(result[i].heightUp), false);
                                                                                     result[i].currentHeight = result[i].heightUp;
@@ -2301,7 +2364,7 @@ function sunProtect() {
                                                                         if (parseFloat(state.val) > parseFloat(result[i].heightDownSun) && parseFloat(state.val) == parseFloat(result[i].currentHeight) && result[i].currentHeight == result[i].heightUp) {
                                                                             result[i].currentAction = 'sunProtect';
                                                                             adapter.log.debug('Sunprotect for ' + result[i].shutterName + ' is active');
-                                                                            adapter.log.debug('Temperatur outside: ' + outsideTemp + ' > ' + result[i].tempOutside + ' OR Light: ' + sunLight + ' > ' + result[i].valueLight);
+                                                                            adapter.log.debug('Temperature outside: ' + outsideTemp + ' > ' + result[i].tempOutside + ' OR Light: ' + sunLight + ' > ' + result[i].valueLight);
                                                                             adapter.log.info('Set ID: ' + result[i].shutterName + ' value: ' + result[i].heightDownSun + '%')
                                                                             adapter.setForeignState(result[i].name, parseFloat(result[i].heightDownSun), false);
                                                                             result[i].currentHeight = result[i].heightDownSun;
@@ -2913,6 +2976,7 @@ function main(adapter) {
             adapter.getForeignState(resultStates[i].name, (err, state) => {
                 if (state) {
                     resultStates[i].currentHeight = (state.val);
+                    resultStates[i].oldHeight = (state.val);
                     resultStates[i].triggerHeight = (state.val);
                     adapter.log.debug('save current height: ' + resultStates[i].currentHeight + '%' + ' from ' + resultStates[i].shutterName);
                 }

--- a/main.js
+++ b/main.js
@@ -182,19 +182,12 @@ function startAdapter(options) {
                     const result = resultID.filter(d => d.name == resShutterID);
                     for ( const i in result) {
                         adapter.getForeignState(result[i].name, (err, state) => {
-                            //if (state && result[i].currentHeight != state.val) {
-                               //adapter.log.debug('old Position value: ' + result[i].currentHeight);
-                            //}
                             adapter.log.debug('Shutter state changed: ' + result[i].shutterName + ' old value = ' + result[i].oldHeight + ' new value = ' + state.val);
                         });
-                        //shutterState(resShutterID);
-                        //setTimeout(function() {
-                        //shutterState(resShutterID);
-                        //},1000)
-                        //Shutter closed -> opened manually to 100% before it has been opened automatically -> enable possibility to activate sunprotect height if required
+                        //Shutter is closed -> opened manually to 100% before it has been opened automatically -> enable possibility to activate sunprotect height if required --> if sunprotect is required: shutter is set to sunProtect height
                         if (result[i].oldHeight == result[i].heightDown && state.val == 100 && result[i].currentAction != 'up') {
                             result[i].currentHeight = state.val;
-                            result[i].currentAction = ''; //reset mode. e.g. mode could be sunProtect if shutter was still closed
+                            result[i].currentAction = ''; //reset mode. e.g. mode could be sunProtect if shutter has still been closed
                             adapter.log.debug(result[i].shutterName + ' opened manually to 100%. Old value = ' + result[i].oldHeight + '. New value = ' + state.val + '. Possibility to activate sunprotect enabled.');
                         }
                         setTimeout(function() {
@@ -2129,8 +2122,7 @@ function sunProtect() {
                                                                     let hysteresisInside = (((100 - result[i].hysteresisInside) / 100) * result[i].tempInside).toFixed(2);
                                                                     let hysteresisLight = (((100 - result[i].hysteresisLight) / 100) * result[i].valueLight).toFixed(2);
 
-                                                                    if (insideTemp < parseFloat(hysteresisInside) || (resultDirectionRangePlus) < azimuth || (parseFloat(hysteresisOutside) > outsideTemp && result[i].lightSensor != '' && parseFloat(hysteresisLight) > sunLight) || (parseFloat(hysteresisOutside) > outsideTemp && result[i].lightSensor == '')) {
-
+                                                                    if (insideTemp < parseFloat(hysteresisInside) || (resultDirectionRangePlus) < azimuth || (parseFloat(hysteresisOutside) > outsideTemp || result[i].lightSensor != '' && parseFloat(hysteresisLight) > sunLight) || (parseFloat(hysteresisOutside) > outsideTemp && result[i].lightSensor == '')) {
                                                                         /**
                                                                          * @param {any} err
                                                                          * @param {{ val: string; }} state


### PR DESCRIPTION
Hi

großes Dank für den Adapter.!Ich setze diesen seit mehreren Monaten für hoch-/runter-Steuerung ein. Seit den letzten paar Wochen im Test zusätzlich für Sonnenschutz.

Ich habe nun in meinem Fork ein paar Änderungen eingebaut, so dass das für mich optimal funktioniert. Läuft so seit mehreren Tagen stabil.
Ich habe die Anpassungen hauptsächlich für mein Szenario umgesetzt und getestet: "Zeit Wohn/Schlaf mit Sonnenauf- & Untergang" / Shuttereinstellungen: Wohn-/Schlafbereich & Sonnenschutz: "in- & outside temperature and direction"

Prüfe doch bitte, ob du hiervon etwas für sinnvoll erachtest und in den Standard übernehmen möchtest. Gerne können wir uns hier abstimmen und ich würde auch helfen Dinge in die anderen Optionen zu integrieren.
Du müsstest helfen speziell bei evtl. Seiteneffekten bei von mir nicht genutzten Optionen.
Alle anderen Dinge belasse ich sonst in meinem Fork.

1) in- & outside temperature and direction - Sonnenschutz aktivieren
Sonnenschutz wird aktiviert wenn Werte überschritten: Innentemp UND Außentemp ODER Sonne
Passt für mich nicht, da ich alle 3 Werte nutze. Es macht keinen Sinn den Sonnenschutz zu aktivieren wenn die Sonne nicht scheint es aber z.B. 25° sind.
Änderung: Innentemp UND ( Außentemp UND Sonne UND Sonne in Verwendung ODER Außentemp UND Sonne nicht in Verwendung )

2) in- & outside temperature and direction - Sonnenschutz deaktivieren
Sonnenschutz wird deaktiviert wenn Werte unterschritten: Innentemp ODER ( Außentemp UND Sonne UND Sonne in Verwendung ODER Außentemp UND Sonne nicht in Verwendung )
Das widerspricht sich meiner Meinug auch etwas zum Aktivieren, oder?
Änderung: Innentemp ODER Außentemp ODER Sonne
Meine Zeile im Coding basiert auf deiner und ist somit komplizierter als eigentlich nötig - ich wollte allerdings möglichst wenig ändern
Funktioniert so für ich, da ich eine hohe Hysterese bei Außentemp verwende und somit faktisch nur bei Innen und Sonne geschaltet wird. Sonst wäre hier für mich Außentemp unnötig bzw. würde ggfs. falsche Effekte liefern.

3) Ein paar weitere Logging-Werte hinzugefügt angepasst.
Hierzu habe ich eine neue Variable result[i].oldHeight eingeführt, um den alten Wert immer korrekt zu speichern. 

4) Neues Feature, bzw. du hast das vorgesehen, hat aber nicht funktioniert: Shutter zu, Sonnenschutz erforderlich, automatisches Auf -> Shutter in Pos Sonnenschutz fahren
siehe Code Kommentar //Shutter closed. Set currentAction = sunProtect when sunProtect starts

5) Neues Feature: reset sunProtect after Adapter restart
Hat immer zu Verwirrung geführt bis ich das kapiert hatte. So fährt der Sonnenschutz auch nach restart wieder hoch-/runter-Steuerung
siehe Code: //Shutter is in position = sunProtect. Maybe restart of adapter. sunProtect not set -> set sunProtect again

6) Neues Feature: Sonnenschutz nach manuellem Auf
Im Schlafbereich werden die Rollladen spät hochgefahren. Sonnenschutz würde eigentlich schon früher starten. Wenn wir aufstehen öffnen wir diese manuell. Danach funktionierte der Sonnenschutz nicht mehr.
Nun wird dieser Fall abgefangen und der Sonnenschutz ermöglicht. Entweder fährt der Rollladen dann automatisch kurz nach dem Öffnen in den Sonnenschutz oder halt später wenn er eintritt
siehe Code: //Shutter is closed -> opened manually to 100% before it has been opened automatically

