### PR TITLE
use weekend down time already on Friday and not on sunday

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ When the adapter crashes or an other Code error happens, this error message that
 
 ## Changelog
 
+### 0.8.7 (2020-08-21)
+* (René) use weekend down time already on Friday and not on sunday
+
 ### 0.8.6 (2020-08-21)
 * (simatec) small Bugfixes trigger
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "shuttercontrol",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "news": {
       "0.8.6": {
         "en": "small Bugfixes trigger",

--- a/main.js
+++ b/main.js
@@ -693,7 +693,7 @@ function shutterDriveCalc() {
     // ******** Set Down-Time Living Area ********
     switch (adapter.config.livingAutomatic) {
         case 'livingTime':
-            if (dayStr === 6 || dayStr === 0 || (HolidayStr) === true || (publicHolidayStr) === true) {
+            if (dayStr === 5 || dayStr === 6 || (HolidayStr) === true || (publicHolidayTomorowStr) === true) {
                 downTimeLiving = adapter.config.WE_shutterDownLiving;
                 debugCnt = 1;
             } else {
@@ -733,7 +733,7 @@ function shutterDriveCalc() {
     // ******** Set Down-Time Sleep Area ******** 
     switch (adapter.config.sleepAutomatic) {
         case 'sleepTime':
-            if (dayStr === 6 || dayStr === 0 || (HolidayStr) === true || (publicHolidayStr) === true) {
+            if (dayStr === 5 || dayStr === 6 || (HolidayStr) === true || (publicHolidayTomorowStr) === true) {
                 downTimeSleep = adapter.config.WE_shutterDownSleep;
                 debugCnt = 1;
             } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.shuttercontrol",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Automatic control for shutters",
   "author": {
     "name": "simatec",


### PR DESCRIPTION
I just changed "dayStr === 6 || dayStr === 0 " to "dayStr === 5 || dayStr === 6" so that shutters close on Friday with weekend setting and Sunday with weekday setting