### PR TITLE
Neue Initialisierungsfunktion zum Aufgreifen des vorherigen Status

### DIFF
--- a/lib/shutterControlInit.js
+++ b/lib/shutterControlInit.js
@@ -1,0 +1,158 @@
+'use strict';
+
+
+ function shutterControlInit(adapter) {
+    // Full Result
+    const resultFull = adapter.config.events;
+
+    if (resultFull) {
+        // Filter enabled
+        let /**
+             * @param {{ enabled: boolean; }} d
+             */
+            resEnabled = resultFull.filter(d => d.enabled === true);
+
+        const result = resEnabled;
+
+        setTimeout(function () {
+            for (const i in result) {
+                
+                if (parseFloat(result[i].heightDown) < parseFloat(result[i].heightUp)) {
+                    adapter.log.debug(result[i].shutterName + ' level conversion is disabled ...');
+                } else if (parseFloat(result[i].heightDown) > parseFloat(result[i].heightUp)) {
+                    adapter.log.debug(result[i].shutterName + ' level conversion is enabled');
+                }
+                
+                /**
+                 * @param {any} err
+                 * @param {{ val: any; }} state
+                 */
+                adapter.getForeignState(result[i].name, (err, state) => {
+                    let nameDevice = result[i].shutterName.replace(/[.;, ]/g, '_');
+                    if (typeof state != undefined && state != null) {
+                        let currentHeight = parseFloat(state.val);
+                        /**
+                         * @param {any} err
+                         * @param {{ val: any; }} state
+                        */
+                        adapter.getState('shutters.autoLevel.'+ nameDevice, (err, state) => {
+                            if (typeof state != undefined && state != null) {
+                                let autoLevel = state.val;
+                                /**
+                                 * @param {any} err
+                                 * @param {{ val: any; }} state
+                                */
+                                adapter.getState('shutters.autoState.'+ nameDevice, (err, state) => {
+                                    if (typeof state != undefined && state != null) {
+                                        let autoState = state.val;
+                                        /**
+                                         * @param {any} err
+                                         * @param {{ val: any; }} state
+                                        */
+                                        adapter.getState('shutters.autoState.'+ nameDevice, (err, state) => {
+                                            if (typeof state != undefined && state != null) {
+                                                let autoState = state.val;
+                                                adapter.log.debug('Init - Trying to map old shutter state for: ' + result[i].shutterName);
+
+                                                if(currentHeight == result[i].heightUp && autoState == 'up') {
+                                                    result[i].currentHeight = currentHeight;
+                                                    result[i].oldHeight = currentHeight;
+                                                    result[i].firstCompleteUp == false;
+                                                    adapter.log.debug('Init current Height: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    adapter.setState('shutters.autoLevel.' + nameDevice, { val: result[i].currentHeight, ack: true });
+                                                    adapter.log.debug('Update current autoLevel: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    result[i].currentAction = 'up'
+                                                    adapter.setState('shutters.autoState.' + nameDevice, { val: result[i].currentAction, ack: true });
+                                                    adapter.log.debug('Init trigger action: ' + result[i].currentAction + ' for device: ' + result[i].shutterName);
+                                                    result[i].triggerAction = result[i].currentAction;
+                                                    result[i].triggerHeight = result[i].currentHeight;
+                                                }
+                                                else if(currentHeight == result[i].heightDown && autoState == 'down') {
+                                                    result[i].currentHeight = currentHeight;
+                                                    result[i].oldHeight = currentHeight;
+                                                    result[i].firstCompleteUp == true;
+                                                    adapter.log.debug('Init current Height: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    adapter.setState('shutters.autoLevel.' + nameDevice, { val: result[i].currentHeight, ack: true });
+                                                    adapter.log.debug('Update current autoLevel: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    result[i].currentAction = 'down'
+                                                    adapter.setState('shutters.autoState.' + nameDevice, { val: result[i].currentAction, ack: true });
+                                                    adapter.log.debug('Init trigger action: ' + result[i].currentAction + ' for device: ' + result[i].shutterName);
+                                                    result[i].triggerAction = result[i].currentAction;
+                                                    result[i].triggerHeight = result[i].currentHeight;
+                                                }
+                                                else if(currentHeight == result[i].triggerDrive && autoState == 'triggered') {
+                                                    result[i].currentHeight = currentHeight;
+                                                    result[i].oldHeight = currentHeight;
+                                                    result[i].firstCompleteUp == false;
+                                                    adapter.log.debug('Init current Height: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    adapter.setState('shutters.autoLevel.' + nameDevice, { val: result[i].currentHeight, ack: true });
+                                                    adapter.log.debug('Update current autoLevel: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    result[i].currentAction = 'triggered'
+                                                    adapter.setState('shutters.autoState.' + nameDevice, { val: result[i].currentAction, ack: true });
+                                                    result[i].triggerHeight = result[i].currentHeight;
+                                                    adapter.log.debug('Init triggerHeight: ' + result[i].triggerHeight + ' for device: ' + result[i].shutterName);
+                                                                                                        
+                                                    if(result[i].triggerDrive == result[i].heightUp) {
+                                                        result[i].triggerAction = 'up'; 
+                                                        adapter.log.debug('Init trigger action: ' + result[i].currentAction + ' for device: ' + result[i].shutterName);
+
+                                                    }
+                                                    else {
+                                                        result[i].triggerAction = 'none';
+                                                        adapter.log.debug('Init trigger action: ' + result[i].currentAction + ' for device: ' + result[i].shutterName);
+                                                    }
+                                                    
+                                                }
+                                                else if(currentHeight == result[i].heightDownSun && (autoState == 'sunProtect' || autoState == 'manu_sunProtect')) {
+                                                    result[i].currentHeight = currentHeight;
+                                                    result[i].oldHeight = currentHeight;
+                                                    result[i].firstCompleteUp = false;
+                                                    adapter.log.debug('Init current Height: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    adapter.setState('shutters.autoLevel.' + nameDevice, { val: result[i].currentHeight, ack: true });
+                                                    adapter.log.debug('Update current autoLevel: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    result[i].currentAction = autoState;
+                                                    adapter.setState('shutters.autoState.' + nameDevice, { val: result[i].currentAction, ack: true });
+                                                    adapter.log.debug('Init trigger action: ' + result[i].currentAction + ' for device: ' + result[i].shutterName);
+                                                    result[i].triggerAction = result[i].currentAction;
+                                                    result[i].triggerHeight = result[i].currentHeight;
+                                                }
+                                                else if(autoState == 'Manu_Mode') {
+                                                    result[i].currentHeight = currentHeight;
+                                                    result[i].oldHeight = currentHeight;
+                                                    result[i].firstCompleteUp == false;
+                                                    adapter.log.debug('Init current Height: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    adapter.setState('shutters.autoLevel.' + nameDevice, { val: result[i].currentHeight, ack: true });
+                                                    adapter.log.debug('Update current autoLevel: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    result[i].currentAction = 'Manu_Mode'
+                                                    adapter.setState('shutters.autoState.' + nameDevice, { val: result[i].currentAction, ack: true });
+                                                    adapter.log.debug('Init trigger action: ' + result[i].currentAction + ' for device: ' + result[i].shutterName);
+                                                    result[i].triggerAction = result[i].currentAction;
+                                                    result[i].triggerHeight = result[i].currentHeight;
+                                                }
+                                                else {
+                                                    adapter.log.debug('Previous state not clear - init to status "none" for device: ' + result[i].shutterName);
+                                                    result[i].currentHeight = currentHeight;
+                                                    result[i].oldHeight = currentHeight;
+                                                    result[i].firstCompleteUp == true;
+                                                    adapter.log.debug('Init current Height: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    adapter.setState('shutters.autoLevel.' + nameDevice, { val: result[i].currentHeight, ack: true });
+                                                    adapter.log.debug('Update current autoLevel: ' + result[i].currentHeight + '%' + ' for ' + result[i].shutterName);
+                                                    result[i].currentAction = 'none'
+                                                    adapter.setState('shutters.autoState.' + nameDevice, { val: result[i].currentAction, ack: true });
+                                                    adapter.log.debug('Init trigger action: ' + result[i].currentAction + ' for device: ' + result[i].shutterName);
+                                                    result[i].triggerAction = result[i].currentAction;
+                                                    result[i].triggerHeight = result[i].currentHeight;
+                                                }
+                                            }
+                                        });
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+        }, 60000);
+    }
+}
+module.exports = shutterControlInit;

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ const utils = require('@iobroker/adapter-core');
 const schedule = require('node-schedule');
 const SunCalc = require('suncalc2');
 
+const shutterControlInit = require('./lib/shutterControlInit');         // ShutterControlInit
 const sunProtect = require('./lib/sunProtect.js');                      // SunProtect
 const triggerChange = require('./lib/triggerChange.js');                // triggerChange
 const elevationDown = require('./lib/elevationDown.js');                // elevationDown
@@ -1790,31 +1791,33 @@ function main(adapter) {
         });
     }
     // set current states
-    const resultStates = adapter.config.events;
+    shutterControlInit(adapter)
 
-    if (resultStates) {
-        for (const i in resultStates) {
-            /**
-             * @param {any} err
-             * @param {{ val: any; }} state
-             */
-            adapter.getForeignState(resultStates[i].name, (err, state) => {
-                if (typeof state != undefined && state != null) {
-                    resultStates[i].currentHeight = (state.val);
-                    resultStates[i].oldHeight = (state.val);
-                    resultStates[i].triggerHeight = (state.val);
-                    resultStates[i].triggerAction = (state.val);
-                    adapter.log.debug('save current height: ' + resultStates[i].currentHeight + '%' + ' from ' + resultStates[i].shutterName);
+    // const resultStates = adapter.config.events;
 
-                    if (parseFloat(resultStates[i].heightDown) < parseFloat(resultStates[i].heightUp)) {
-                        adapter.log.debug(resultStates[i].shutterName + ' level conversion is disabled ...');
-                    } else if (parseFloat(resultStates[i].heightDown) > parseFloat(resultStates[i].heightUp)) {
-                        adapter.log.debug(resultStates[i].shutterName + ' level conversion is enabled');
-                    }
-                }
-            });
-        }
-    }
+    // if (resultStates) {
+    //    for (const i in resultStates) {
+    //        /**
+    //         * @param {any} err
+    //         * @param {{ val: any; }} state
+    //         */
+    //        adapter.getForeignState(resultStates[i].name, (err, state) => {
+    //            if (typeof state != undefined && state != null) {
+    //                resultStates[i].currentHeight = (state.val);
+    //                resultStates[i].oldHeight = (state.val);
+    //                resultStates[i].triggerHeight = (state.val);
+    //                resultStates[i].triggerAction = (state.val);
+    //                adapter.log.debug('save current height: ' + resultStates[i].currentHeight + '%' + ' from ' + resultStates[i].shutterName);
+
+    //                if (parseFloat(resultStates[i].heightDown) < parseFloat(resultStates[i].heightUp)) {
+    //                    adapter.log.debug(resultStates[i].shutterName + ' level conversion is disabled ...');
+    //                } else if (parseFloat(resultStates[i].heightDown) > parseFloat(resultStates[i].heightUp)) {
+    //                    adapter.log.debug(resultStates[i].shutterName + ' level conversion is enabled');
+    //                }
+    //            }
+    //        });
+    //    }
+    // }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hallo Simatec
Nachdem es bei vielen Usern immer wieder Probleme gab betr. Adapter Neustart und Initialisierung (hat mich mehrfach auch schon erwischt), habe ich mit meinen bescheidenen Mitteln mal eine Init Funktion geschrieben, welche beim Startup - nach dem Aufräumen der Objekte - den Shuttercontrol initialisiert. Dabei werden die aktuellen Rollo Höhen einmalig eingelesen und in Kombination mit den noch existierenden shuttercontrol.0.shutters.autoXxxx Objektwerten versucht den letzten Status zu rekonstruieren und somit die internen Zustände wieder korrekt zu setzen.
Gelingt dies nicht, wird eine Standartinitialisierung verwendet unter Berücksichtigung der aktuellen Höhe.
Ich habe dies heute bei mir im Live in Betrieb genommen und es funktioniert mal soweit. Aktuelle Zustände werden bei mir nach dem Restart des Adapters korrekt wieder hergestellt, und der Adapter läuft ohne weiteres Zutun mit den initialisierten Zuständen korrekt an der Stelle weiter, wo her vorher gestoppt wurde. Sprich, z.B. ein Trigger wird nach dem Start korrekt gesetzt und beim Schliessen fährt der Rollo wieder korrekt zu. (Heute motzt mich dieser an, da der "Rückfahrwert" durch den Neustart verloren ging und somit "_null_" ist.)
Kannst Du Dir dies bitte mal anschauen und prüfen, ob das so ins Shuttercontrol Konzept passt? Wäre cool, wenn Du es in Deiner Umgebung auch mal testen und mir Feedback geben könntest  ob es auch bei Dir läuft.
Hoffe, die neue Init Funktion gefällt Dir und es gibt in Zukunft viel weniger "Klagen", dass was nicht tut oder nicht gefahren sei ;-)
Viele Grüsse, Roli

PS. Den von mir aus kommentierte Code im main.js kannst Du löschen, wenn Du das willst. Habe das zum besseren Verständnis aktuell noch drin belassen.