### PR TITLE
Bugfix wrongly open after deactivation of weater alarm

### DIFF
--- a/lib/sunProtect.js
+++ b/lib/sunProtect.js
@@ -199,7 +199,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     adapter.log.info('SunProtect not moving up now due to active alarm: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightUp + '%');
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
@@ -242,7 +242,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     adapter.log.info('SunProtect not moving up now due to active alarm: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightUp + '%');
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
@@ -410,7 +410,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -454,7 +454,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -617,7 +617,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -659,7 +659,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -787,7 +787,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -818,7 +818,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -976,7 +976,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -1020,7 +1020,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -1150,7 +1150,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -1183,7 +1183,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
                                                         }
                                                     }
-                                                } else {
+                                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                                     shutterSettings[s].sunProtectEndtimerid = '';
                                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                                     shutterSettings[s].alarmTriggerAction = 'up';
@@ -1271,7 +1271,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             adapter.log.debug('save current height: ' + shutterSettings[s].currentHeight + '%' + ' from ' + shutterSettings[s].shutterName);
                                         }
                                     }
-                                } else {
+                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                     shutterSettings[s].sunProtectEndtimerid = '';
                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                     shutterSettings[s].alarmTriggerAction = 'none';
@@ -1304,7 +1304,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             shutterSettings[s].sunProtectEndtimerid = ''
                                         }
                                     }
-                                } else {
+                                } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
                                     shutterSettings[s].sunProtectEndtimerid = '';
                                     shutterSettings[s].alarmTriggerLevel = parseFloat(shutterSettings[s].heightUp);
                                     shutterSettings[s].alarmTriggerAction = 'none';


### PR DESCRIPTION
Hi Simatec
Habe gestern morgen mit erstaunen festgestellt, dass sich meine Rollos nach dem Aufheben des Windalarms öffnen, anstatt schliessen. Beim Logging habe ich dann gesehen, dass da sunProtect dazwischen funkt und im "Hintergrund" die Rollos öffnen will, obwohl diese ja nie im sunProtect Modus waren. Das war dann auch der Bug.
Habe dies nun gefixt und heute morgen lief alles korrekt.
PS. Dieses Verhalten passt auch zu einigen gemeldeten Fragen im Forum, wonach sich einige darüber beklagt haben, dass die Rollos immer auf und zu fahren, wenn der Windalarm kommt und geht.