### PR TITLE
fix ending sunProtect with open door

### DIFF
--- a/lib/sunProtect.js
+++ b/lib/sunProtect.js
@@ -101,7 +101,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                                 await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightDownSun), nameDevice, 'Sunprotect #410');
 
-                                                                adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active');
+                                                                adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active (1)');
                                                                 adapter.log.debug('Temperature inside: ' + insideTemp + ' > ' + shutterSettings[s].tempInside + ' AND ( Temperatur outside: ' + outsideTemp + ' > ' + shutterSettings[s].tempOutside + ' AND Light: ' + sunLight + ' > ' + shutterSettings[s].valueLight + ' )');
                                                                 adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
                                                                 adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightDownSun + '%');
@@ -145,7 +145,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                                 shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightDownSun);
                                                                 shutterSettings[s].triggerAction = 'sunProtect';
 
-                                                                adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                                adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (1)');
                                                                 adapter.log.debug('save new trigger height: ' + shutterSettings[s].heightDownSun + '%');
                                                                 adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
                                                             }
@@ -164,8 +164,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisInside = (((100 - shutterSettings[s].hysteresisInside) / 100) * shutterSettings[s].tempInside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(1) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -185,7 +185,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightUp), nameDevice, 'Sunprotect #411');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active (1)');
                                                             adapter.log.debug('Temperature inside: ' + insideTemp + ' < ' + hysteresisInside + ' OR ( Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' OR Light: ' + sunLight + ' < ' + hysteresisLight + ' )');
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightDownSun + '%')
@@ -196,7 +196,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await adapter.setStateAsync('shutters.autoState.' + nameDevice, { val: shutterSettings[s].currentAction, ack: true }).catch((e) => adapter.log.warn(e));
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (1)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -212,8 +212,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisInside = (((100 - shutterSettings[s].hysteresisInside) / 100) * shutterSettings[s].tempInside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(2) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -229,9 +229,9 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightUp);
                                                             shutterSettings[s].triggerAction = 'up';
 
-                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (1)');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore (1)');
                                                             adapter.log.debug('Temperature inside: ' + insideTemp + ' < ' + hysteresisInside + ' OR ( Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' OR Light: ' + sunLight + ' < ' + hysteresisLight + ' )');
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].triggerHeight + '%');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
@@ -239,7 +239,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                         else if (shutterSettings[s].currentAction == 'OpenInSunProtect') {
                                                             shutterSettings[s].sunProtectEndtimerid = ''
                                                             shutterSettings[s].triggerAction = 'none';
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (2)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -312,7 +312,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                                 await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightDownSun), nameDevice, 'Sunprotect #412');
 
-                                                                adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active');
+                                                                adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active (2)');
                                                                 adapter.log.debug('Temperature inside: ' + insideTemp + ' > ' + shutterSettings[s].tempInside + ' AND ( Temperatur outside: ' + outsideTemp + ' > ' + shutterSettings[s].tempOutside + ' AND Light: ' + sunLight + ' > ' + shutterSettings[s].valueLight + ' )');
                                                                 adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightDownSun + '%');
                                                                 adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
@@ -354,7 +354,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                                 shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightDownSun);
                                                                 shutterSettings[s].triggerAction = 'sunProtect';
 
-                                                                adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                                adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (2)');
 
                                                                 adapter.log.debug('save new trigger height: ' + shutterSettings[s].heightDownSun + '%');
                                                                 adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
@@ -374,8 +374,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisInside = (((100 - shutterSettings[s].hysteresisInside) / 100) * shutterSettings[s].tempInside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(3) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -397,7 +397,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightUp), nameDevice, 'Sunprotect #413');
 
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active (2)');
                                                             adapter.log.debug('Range: ' + resultDirectionRangePlus + ' < ' + azimuth + ' OR Temperature inside: ' + insideTemp + ' < ' + hysteresisInside + ' OR ( Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' OR Light: ' + sunLight + ' < ' + hysteresisLight + ')');
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightUp + '%');
                                                         }
@@ -407,7 +407,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await adapter.setStateAsync('shutters.autoState.' + nameDevice, { val: shutterSettings[s].currentAction, ack: true }).catch((e) => adapter.log.warn(e));
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (3)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -424,8 +424,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisInside = (((100 - shutterSettings[s].hysteresisInside) / 100) * shutterSettings[s].tempInside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(4) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -441,9 +441,9 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightUp);
                                                             shutterSettings[s].triggerAction = 'up';
 
-                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (2)');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore (2)');
                                                             adapter.log.debug('Temperature inside: ' + insideTemp + ' < ' + hysteresisInside + ' OR ( Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' OR Light: ' + sunLight + ' < ' + hysteresisLight + ' )');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].triggerHeight + '%');
@@ -451,7 +451,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                         else if (shutterSettings[s].currentAction == 'OpenInSunProtect') {
                                                             shutterSettings[s].triggerAction = 'none';
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (4)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -520,7 +520,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                                 await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightDownSun), nameDevice, 'Sunprotect #414');
 
                                                                 adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
-                                                                adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active');
+                                                                adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active (3)');
                                                                 adapter.log.debug('Temperatur outside: ' + outsideTemp + ' > ' + shutterSettings[s].tempOutside + ' AND Light: ' + sunLight + ' > ' + shutterSettings[s].valueLight);
                                                                 adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightDownSun + '%')
                                                             }
@@ -564,7 +564,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                                 shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightDownSun);
                                                                 shutterSettings[s].triggerAction = 'sunProtect';
 
-                                                                adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                                adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (3)');
 
                                                                 adapter.log.debug('save new trigger height: ' + shutterSettings[s].heightDownSun + '%');
                                                                 adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
@@ -584,8 +584,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisOutside = (((100 - shutterSettings[s].hysteresisOutside) / 100) * shutterSettings[s].tempOutside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(5) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -604,7 +604,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightUp), nameDevice, 'Sunprotect #415');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active (3)');
                                                             adapter.log.debug('Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' OR Light: ' + sunLight + ' < ' + hysteresisLight);
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightUp + '%')
@@ -614,7 +614,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await adapter.setStateAsync('shutters.autoState.' + nameDevice, { val: shutterSettings[s].currentAction, ack: true }).catch((e) => adapter.log.warn(e));
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (5)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -630,8 +630,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisOutside = (((100 - shutterSettings[s].hysteresisOutside) / 100) * shutterSettings[s].tempOutside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(6) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -646,9 +646,9 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightUp);
                                                             shutterSettings[s].triggerAction = 'up';
 
-                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (3)');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore (3)');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].triggerHeight + '%');
                                                         }
@@ -656,7 +656,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].sunProtectEndtimerid = ''
                                                             shutterSettings[s].triggerAction = 'none';
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (6)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -703,7 +703,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightDownSun), nameDevice, 'Sunprotect #416');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active (4)');
                                                             adapter.log.debug('RangeMinus: ' + resultDirectionRangeMinus + ' < ' + azimuth + 'RangePlus: ' + resultDirectionRangePlus + ' > ' + azimuth);
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightDownSun + '%');
@@ -746,7 +746,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightDownSun);
                                                             shutterSettings[s].triggerAction = 'sunProtect';
 
-                                                            adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (4)');
 
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].heightDownSun + '%');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
@@ -775,7 +775,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightUp), nameDevice, 'Sunprotect #417');
 
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active (4)');
                                                             adapter.log.debug('Range: ' + resultDirectionRangePlus + ' < ' + azimuth);
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightUp + '%')
                                                         }
@@ -784,7 +784,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await adapter.setStateAsync('shutters.autoState.' + nameDevice, { val: shutterSettings[s].currentAction, ack: true }).catch((e) => adapter.log.warn(e));
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (7)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -806,16 +806,16 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightUp);
                                                             shutterSettings[s].triggerAction = 'up';
 
-                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (4)');
 
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].triggerHeight + '%');
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore (4)');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
                                                         }
                                                         else if (shutterSettings[s].currentAction == 'OpenInSunProtect') {
                                                             shutterSettings[s].triggerAction = 'none';
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (8)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -879,7 +879,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightDownSun), nameDevice, 'Sunprotect #418');
 
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active (5)');
                                                             adapter.log.debug('Temperature outside: ' + outsideTemp + ' > ' + shutterSettings[s].tempOutside + ' AND Light: ' + sunLight + ' > ' + shutterSettings[s].valueLight);
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightDownSun + '%');
                                                         }
@@ -922,7 +922,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightDownSun);
                                                             shutterSettings[s].triggerAction = 'sunProtect';
 
-                                                            adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (5)');
 
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].heightDownSun + '%');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
@@ -942,8 +942,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisOutside = (((100 - shutterSettings[s].hysteresisOutside) / 100) * shutterSettings[s].tempOutside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(7) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -963,7 +963,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightUp), nameDevice, 'Sunprotect #419');
 
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active (5)');
                                                             adapter.log.debug('Temperature outside: ' + outsideTemp + ' < ' + hysteresisOutside + ' OR Light: ' + sunLight + ' < ' + hysteresisLight);
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightUp + '%');
                                                         }
@@ -973,7 +973,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await adapter.setStateAsync('shutters.autoState.' + nameDevice, { val: shutterSettings[s].currentAction, ack: true }).catch((e) => adapter.log.warn(e));
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (9)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -989,8 +989,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             const hysteresisOutside = (((100 - shutterSettings[s].hysteresisOutside) / 100) * shutterSettings[s].tempOutside).toFixed(2);
                                             const hysteresisLight = (((100 - shutterSettings[s].hysteresisLight) / 100) * shutterSettings[s].valueLight).toFixed(2);
 
-                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && shutterSettings[s].currentAction == 'sunProtect' && shutterSettings[s].KeepSunProtect === false) {
-                                                adapter.log.debug('Started sunprotect end delay for ' + shutterSettings[s].shutterName);
+                                            if (shutterSettings[s].sunProtectEndtimerid === '' && shutterSettings[s].lightSensor != '' && parseFloat(hysteresisLight) > sunLight && (shutterSettings[s].currentAction == 'sunProtect' || shutterSettings[s].currentAction == 'triggered') && shutterSettings[s].KeepSunProtect === false) {
+                                                adapter.log.debug('(8) Started sunprotect end delay for ' + shutterSettings[s].shutterName);
                                                 shutterSettings[s].sunProtectEndtimerid = setTimeout(async function () {
                                                     shutterSettings[s].sunProtectEndtimerid = '0';
                                                 }, shutterSettings[s].sunProtectEndDely * 60000, i);
@@ -1006,9 +1006,9 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerAction = 'up';
                                                             shutterSettings[s].sunProtectEndtimerid = '';
 
-                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (5)');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore (5)');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].triggerHeight + '%');
                                                         }
@@ -1017,7 +1017,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerAction = 'none';
                                                             shutterSettings[s].sunProtectEndtimerid = '';
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (10)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -1067,7 +1067,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightDownSun), nameDevice, 'Sunprotect #420');
 
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is active (6)');
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightDownSun + '%');
                                                         }
@@ -1109,7 +1109,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerAction = 'sunProtect';
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightDownSun);
 
-                                                            adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (6)');
 
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].heightDownSun + '%');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
@@ -1139,7 +1139,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             await setShutterState(adapter, shutterSettings, shutterSettings[s], parseFloat(shutterSettings[s].heightUp), nameDevice, 'Sunprotect #421');
 
                                                             adapter.log.debug(`last automatic Action for ${shutterSettings[s].shutterName}: ${shutterSettings[s].lastAutoAction}`);
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active (6)');
                                                             adapter.log.debug('Sunprotect ' + shutterSettings[s].shutterName + ' old height: ' + shutterSettings[s].oldHeight + '% new height: ' + shutterSettings[s].heightUp + '%');
                                                         }
                                                         else if (shutterSettings[s].currentAction == 'OpenInSunProtect') {
@@ -1147,7 +1147,7 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
 
                                                             await adapter.setStateAsync('shutters.autoState.' + nameDevice, { val: shutterSettings[s].currentAction, ack: true }).catch((e) => adapter.log.warn(e));
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (11)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -1171,16 +1171,16 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightUp);
                                                             shutterSettings[s].triggerAction = 'up';
 
-                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (6)');
 
                                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].triggerHeight + '%');
-                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore');
+                                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore (6)');
                                                             adapter.log.debug('save new trigger action: ' + shutterSettings[s].triggerAction);
                                                         }
                                                         else if (shutterSettings[s].currentAction == 'OpenInSunProtect') {
                                                             shutterSettings[s].triggerAction = 'none';
 
-                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active');
+                                                            adapter.log.debug('OpenInSunProtect for ' + shutterSettings[s].shutterName + ' is not longer active (12)');
                                                         }
                                                     }
                                                 } else if (shutterSettings[s].alarmTriggerAction == 'sunProtect') {
@@ -1295,8 +1295,8 @@ async function sunProtect(adapter, elevation, azimuth, shutterSettings) {
                                             shutterSettings[s].triggerHeight = parseFloat(shutterSettings[s].heightUp);
                                             shutterSettings[s].triggerAction = 'up';
                                             shutterSettings[s].sunProtectEndtimerid = '';
-                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore');
-                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed ');
+                                            adapter.log.debug('Sunprotect for ' + shutterSettings[s].shutterName + ' is not active anymore (7)');
+                                            adapter.log.info(' Will end sunprotect ID: ' + shutterSettings[s].shutterName + ' value: ' + shutterSettings[s].heightDownSun + '%' + ' after the window has been closed (7)');
 
                                             adapter.log.debug('save new trigger height: ' + shutterSettings[s].triggerHeight + '%');
 


### PR DESCRIPTION
fixes issue [https://github.com/simatec/ioBroker.shuttercontrol/issues/481](https://github.com/simatec/ioBroker.shuttercontrol/issues/481):
- start sun prodect end delay in case of currend shutter action is 'sunProdect' OR 'triggered'

additionally extended some debug messages to easier find concerned lines in coding.