### PR TITLE
require node 16 as adapter-core 3.x.x is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/simatec/ioBroker.shuttercontrol"
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },  
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "node-schedule": "^2.1.1",


### PR DESCRIPTION
Adapter-core 3.x.x is known to fail when installed at node 14 due to npm7 not installing peer dependencies. So this adapter requires node 16