### PR TITLE
Fix for issue #773: Frost alarm is now considered even when shutters are already closed.

### DIFF
--- a/lib/shutterAlarm.js
+++ b/lib/shutterAlarm.js
@@ -565,7 +565,7 @@ async function shutterAlarm(adapter, alarmType, shutterSettings) {
                                             shutterSettings[s].triggerHeight = parseFloat(alarmFrostLevel);
                                             shutterSettings[s].triggerAction = 'frost';
                                         }
-                                    } else if (_shutterState?.val !== null && _shutterState?.val !== undefined == shutterSettings[s].heightDown &&
+                                    } else if (_shutterState?.val !== null && _shutterState?.val !== undefined && _shutterState?.val == shutterSettings[s].heightDown &&
                                         (currentValue === mustValue ||
                                             currentValue === mustValueTilted ||
                                             currentValue == '')) {


### PR DESCRIPTION
Fix for issue #773 

Repro steps:
- Close shutters
- Trigger frost alarm

Current behaviour (not as expected):
- Shutters remain in status "down"

Changed behaviour (as expected):
- Shutters will change to status "frost"